### PR TITLE
cursory typescript support

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,4 +4,4 @@ export const CWD = process.cwd()
 export const PRESTA_DIR = path.join(CWD, '.presta')
 export const PRESTA_PAGES = path.join(PRESTA_DIR, 'pages')
 export const PRESTA_WRAPPED_PAGES = path.join(PRESTA_DIR, 'wrapped')
-export const PRESTA_RUNTIME_DEFAULT = path.join(CWD, 'presta.runtime.js')
+export const PRESTA_RUNTIME_DEFAULT = path.join(CWD, 'presta.runtime') // no extension

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "presta",
-  "version": "0.7.0",
+  "version": "0.7.0-ts1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "presta",
-  "version": "0.7.0-ts1",
+  "version": "0.7.0-ts2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "presta",
-  "version": "0.7.0-ts2",
+  "version": "0.7.0-ts3",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "presta",
-  "version": "0.7.0",
+  "version": "0.7.0-ts1",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "presta",
-  "version": "0.7.0-ts1",
+  "version": "0.7.0-ts2",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/presta.js
+++ b/presta.js
@@ -18,7 +18,7 @@ const pragma = {
 }
 
 const babel = {
-  extensions: ['.ts', '.tsx', '.js', '.jsx'],
+  extensions: ['.js', '.jsx', '.ts', '.tsx'],
   presets: [['@babel/preset-react', pragma[jsx] || pragma.h]]
 }
 

--- a/presta.js
+++ b/presta.js
@@ -4,28 +4,29 @@ require = require('esm')(module)
 
 const path = require('path')
 
-const [_, jsx] = process.argv.join(' ').match(/--jsx[\s|=]([^-]+)/) || []
+const [_, jsx = 'h'] = process.argv.join(' ').match(/--jsx[\s|=]([^-]+)/) || []
 
-const jsxPragmas = {
+const pragma = {
+  h: {
+    pragma: 'h',
+    pragmaFrag: 'h'
+  },
   react: {
     pragma: 'React.createElement',
     pragmaFrag: 'React.Fragment'
   }
 }
 
-require('@babel/register')({
-  extends: path.join(process.cwd(), 'babel.config.js'),
-  extensions: ['.js', '.jsx', '.ts', '.tsx'],
-  presets: [
-    [
-      '@babel/preset-react',
-      jsxPragmas[jsx] || {
-        pragma: jsx || 'h',
-        pragmaFrag: jsx || 'h'
-      }
-    ]
-  ]
-})
+const babel = {
+  extensions: ['.ts', '.tsx', '.js', '.jsx'],
+  presets: [['@babel/preset-react', pragma[jsx] || pragma.h]]
+}
+
+try {
+  babel.extends = require.resolve(path.join(process.cwd(), 'babel.config.js'))
+} catch (e) {}
+
+require('@babel/register')(babel)
 
 require('module-alias').addAliases({
   '@': process.cwd()

--- a/presta.js
+++ b/presta.js
@@ -2,13 +2,24 @@
 
 require = require('esm')(module)
 
+const path = require('path')
+
 const [_, jsx] = process.argv.join(' ').match(/--jsx[\s|=]([^-]+)/) || []
 
+const jsxPragmas = {
+  react: {
+    pragma: 'React.createElement',
+    pragmaFrag: 'React.Fragment'
+  }
+}
+
 require('@babel/register')({
+  extends: path.join(process.cwd(), 'babel.config.js'),
+  extensions: ['.js', '.jsx', '.ts', '.tsx'],
   presets: [
     [
       '@babel/preset-react',
-      {
+      jsxPragmas[jsx] || {
         pragma: jsx || 'h',
         pragmaFrag: jsx || 'h'
       }


### PR DESCRIPTION
Doesn't include any types, but allows user to provide a `babel.config.js` and _should_ allow `.ts` and `.tsx` files to be sourced if `@babel/preset-typescript` is configured.