### PR TITLE
Fix 'main' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "presta",
   "version": "0.17.0",
   "description": "The simple way to build the modern web.",
-  "main": "index.js",
+  "main": "presta.js",
   "bin": {
     "presta": "presta.js"
   },


### PR DESCRIPTION
Problem: The 'main' property points at index.js, which doesn't exist.

Solution: Modify 'main' to reference presta.js, which exists.