### PR TITLE
fix(watch): ignore updates to empty directories

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -230,6 +230,7 @@ export async function watch (config, options = {}) {
    */
   entryWatcher.on('all', async (event, file) => {
     if (!/add|change/.test(event)) return
+    if (fs.lstatSync(file).isDirectory()) return
 
     const isStat = isStatic(file)
     const isDyn = isDynamic(file)


### PR DESCRIPTION
was previously trying to read empty dirs as static/dynamic pages

Fixes #28