### PR TITLE
extract

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const fs = require('fs-extra')
 const sade = require('sade')
 const exit = require('exit')
 const c = require('ansi-colors')
@@ -60,6 +61,8 @@ prog
       }
     })
 
+    fs.emptyDirSync(config.merged.output)
+
     log(`${c.blue('~ presta build')}\n`)
 
     await build(config)
@@ -88,6 +91,8 @@ prog
         files: opts._
       }
     })
+
+    fs.emptyDirSync(config.merged.output)
 
     if (!opts.n) {
       const server = await serve(config, { noBanner: true })

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "start": "npm run build && presta watch './src/pages/**/*.jsx'",
-    "build": "webpack -p && presta build './src/pages/**/*.jsx'",
+    "build": "webpack -p && NODE_ENV=production presta build './src/pages/**/*.jsx'",
     "client": "webpack -w",
     "format": "prettier-standard --format"
   },

--- a/docs/src/pages/Docs.jsx
+++ b/docs/src/pages/Docs.jsx
@@ -9,6 +9,7 @@ import unified from 'unified'
 import markdown from 'remark-parse'
 import remarkHtml from 'remark-html'
 import highlight from 'remark-highlight.js'
+import * as extract from 'presta/extract'
 
 import { title } from '@/src/lib/title'
 import * as document from '@/src/lib/document'
@@ -19,7 +20,6 @@ import { Github } from '@/src/icons/Github'
 import { Logo } from '@/src/components/Logo'
 
 export async function getStaticPaths () {
-  // const [file] = source(path.resolve(__dirname, '../content/docs.md'))
   return ['/docs']
 }
 
@@ -87,7 +87,10 @@ export async function handler (ctx) {
       description: 'Hyper minimal framework for the modern web.',
       head: {
         ...head,
-        style: [...(head.style || []), { id: 'style', children: hypo.flush() }]
+        link: [
+          ...head.link,
+          { rel: 'stylesheet', href: extract.css(hypo.flush()) }
+        ]
       },
       body: body,
       foot: document.foot(ctx)

--- a/docs/src/pages/Index.jsx
+++ b/docs/src/pages/Index.jsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { Hypo, Box } from '@hypobox/react'
 import { html } from 'presta/html'
 import { hypostyle } from 'hypostyle'
+import * as extract from 'presta/extract'
 
 import { title } from '@/src/lib/title'
 import * as document from '@/src/lib/document'
@@ -271,7 +272,10 @@ export function handler (ctx) {
       description: 'Hyper minimal framework for the modern web.',
       head: {
         ...head,
-        style: [...(head.style || []), { id: 'style', children: hypo.flush() }]
+        link: [
+          ...head.link,
+          { rel: 'stylesheet', href: extract.css(hypo.flush()) }
+        ]
       },
       body: body,
       foot: document.foot(ctx)

--- a/extract.js
+++ b/extract.js
@@ -1,0 +1,51 @@
+const fs = require('fs')
+const path = require('path')
+
+const { OUTPUT_STATIC_DIR } = require('./lib/constants')
+const { getCurrentConfig } = require('./lib/config')
+
+function hash (str) {
+  var h = 5381,
+    i = str.length
+
+  while (i) h = (h * 33) ^ str.charCodeAt(--i)
+
+  return (h >>> 0).toString(36)
+}
+
+function extract (raw, ext, key = '') {
+  const { env, cwd, merged: config } = getCurrentConfig()
+  const PROD = env === 'production'
+
+  let filename = key
+
+  if (PROD) {
+    if (key) {
+      filename = key + '-' + hash(raw)
+    } else {
+      filename = hash(raw)
+    }
+  } else if (!PROD && !key) {
+    filename = hash(raw)
+  }
+
+  const publicPath = '/' + filename + '.' + ext
+
+  fs.writeFileSync(path.join(config.output, OUTPUT_STATIC_DIR, publicPath), raw)
+
+  return publicPath
+}
+
+function css (raw, key) {
+  return extract(raw, 'css', key)
+}
+
+function js (raw, key) {
+  return extract(raw, 'js', key)
+}
+
+module.exports = {
+  extract,
+  css,
+  js
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1282,8 +1282,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/sure-thing/presta#readme",
   "dependencies": {
     "ansi-colors": "^4.1.1",
+    "callsites": "^3.1.0",
     "chokidar": "^3.4.3",
     "debug": "^4.1.1",
     "deepmerge": "^4.2.2",


### PR DESCRIPTION
Extract generated files at build time. Filename defaults to the name of the file where `css/js` is called i.e. if `pages/Docs.jsx` calls `extract.css`, it will generate a `Docs.css` file during development. In production, the file is hashed, so it'll be `Docs-ske13jd.css` or whatever.

```
import * as extract from 'presta/extract'

extract.css(`.class { color: blue }`)
extract.js(`const foo = 'bar'`)
```

This PR also _clears_ the build directory on process startup, since these methods can generate lots of side-effects files.