### PR TITLE
fix: generate proper import path for pages on windows when building

### DIFF
--- a/lib/createDynamicEntry.js
+++ b/lib/createDynamicEntry.js
@@ -20,7 +20,10 @@ ${
     : `const userConfig = {}`
 }
 ${sourceFiles
-  .map((file, i) => `import * as Template${i} from '${file}';`)
+  .map(
+    (file, i) =>
+      `import * as Template${i} from '${file.replace(/\\/g, '\\\\')}';`
+  )
   .join('\n')}
 
 export const config = Object.assign({}, userConfig, ${serialize(config)});


### PR DESCRIPTION
Fixes #63 
The path to the template files was using the correct seperator '\' but it wasn't escaped.