### PR TITLE
fix: errors during build should be fatal

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -54,7 +54,7 @@ prog
 
     const config = createConfig({
       env: 'production',
-      configFile: getConfigFile(opts.config),
+      configFile: getConfigFile(opts.config, true),
       cliArgs: {
         ...opts,
         files: opts._

--- a/lib/build.js
+++ b/lib/build.js
@@ -27,7 +27,7 @@ async function build (config, options = {}) {
     let dynamicTime = 0
     let copyTime = 0
 
-    await Promise.allSettled([
+    const tasks = await Promise.allSettled([
       (async () => {
         if (staticIds.length) {
           const time = timer()
@@ -72,6 +72,12 @@ async function build (config, options = {}) {
         }
       })()
     ])
+
+    // since we're building (not watch) if any task fails, exit with error
+    if (tasks.find(task => task.status === 'rejected')) {
+      process.exit(1)
+      return
+    }
 
     log('')
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,17 +21,21 @@ function resolvePaths (obj) {
   return obj
 }
 
-function getConfigFile (filepath) {
-  /*
-   * Since we want to let the user know right away if their config has issues,
-   * just try to require it right away
-   */
+/**
+ * Fetch a config file. If one was specified by the user, let them know if
+ * anything goes wrong. Outside watch mode, this should exit(1) if the user
+ * provided a config and there was an error
+ */
+function getConfigFile (filepath, shouldExit) {
   try {
     return require(path.resolve(filepath || CONFIG_DEFAULT))
   } catch (e) {
     // if user specified a file, must be a syntax error
     if (!!filepath) {
       log(`${c.red('~ error')} ${filepath}\n\n  > ${e.stack || e}\n`)
+
+      // we're not in watch mode, exit
+      if (shouldExit) process.exit(1)
     }
 
     return {}

--- a/lib/createDynamicEntry.js
+++ b/lib/createDynamicEntry.js
@@ -1,7 +1,6 @@
 const fs = require('fs-extra')
 const path = require('path')
 
-const { CONFIG_DEFAULT } = require('./constants')
 const { debug } = require('./debug')
 const { serialize } = require('./config')
 

--- a/lib/renderStaticEntries.js
+++ b/lib/renderStaticEntries.js
@@ -19,22 +19,6 @@ function renderStaticEntries (entries, config, options = {}) {
 
     const allGeneratedFiles = []
 
-    function onError (e, { location }) {
-      if (options.watch) {
-        log(
-          `\n  ${c.red('error')} ${location}\n\n  > ${e.stack || e}\n\n${c.gray(
-            `  errors detected, pausing...`
-          )}\n`
-        )
-      } else {
-        log(`\n  ${c.red('error')} ${location}\n\n  > ${e.stack || e}\n`)
-
-        if (process.env.NODE_ENV === 'test') console.error(e)
-      }
-
-      y({ allGeneratedFiles })
-    }
-
     for (const entry of entries) {
       try {
         delete require.cache[entry]
@@ -83,10 +67,20 @@ function renderStaticEntries (entries, config, options = {}) {
       } catch (e) {
         const location = entry.replace(config.cwd, '')
 
-        onError(e, { location })
+        if (config.env === 'development') {
+          log(
+            `\n  ${c.red('error')} ${location}\n\n  > ${e.stack ||
+              e}\n\n${c.gray(`  errors detected, pausing...`)}\n`
+          )
 
-        n(e)
+          y({ allGeneratedFiles })
+        } else {
+          log(`\n  ${c.red('error')} ${location}\n\n  > ${e.stack || e}\n`)
 
+          n(e)
+        }
+
+        // exit loop on any error
         break
       }
     }


### PR DESCRIPTION
Ensures that `presta build` exits with errors, if they occur. Previously the build would exit(0),
even if some files weren't built.

fixes #56