### PR TITLE
feat: output manifest.json

### DIFF
--- a/.changeset/breezy-cheetahs-thank.md
+++ b/.changeset/breezy-cheetahs-thank.md
@@ -1,0 +1,9 @@
+---
+'@presta/adapter-cloudflare-workers': minor
+'@presta/adapter-netlify': minor
+'@presta/adapter-node': minor
+'@presta/adapter-vercel': minor
+'presta': minor
+---
+
+Output and consume manifest.json

--- a/packages/adapter-netlify/__tests__/index.ts
+++ b/packages/adapter-netlify/__tests__/index.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { suite } from 'uvu'
 import * as assert from 'uvu/assert'
 import { afix } from 'afix'
+import { ManifestDynamicFile } from 'presta'
 
 import createPlugin, {
   toAbsolutePath,
@@ -29,7 +30,13 @@ test('normalizeNetlifyRoute', async () => {
 })
 
 test('prestaRoutesToNetlifyRedirects', async () => {
-  assert.equal(prestaRoutesToNetlifyRedirects([['*', 'Func']])[0], {
+  const dynamicFile: ManifestDynamicFile = {
+    type: 'dynamic',
+    src: 'src',
+    dest: 'Func',
+    route: '/*',
+  }
+  assert.equal(prestaRoutesToNetlifyRedirects([dynamicFile])[0], {
     from: '/*',
     to: '/.netlify/functions/Func',
     status: 200,
@@ -171,7 +178,7 @@ test('onPostBuild - just static, netlify config matches presta config', async ()
     output: path.join(fixtures.root, 'build'),
     staticOutput: path.join(fixtures.root, 'build/static'),
     functionsOutput: path.join(fixtures.root, 'build/functions'),
-    functionsManifest: {},
+    manifest: { files: [] },
   }
 
   await onPostBuild(config, props)
@@ -196,7 +203,7 @@ test('onPostBuild - just static, netlify config does not match presta config', a
     output: path.join(fixtures.root, 'build'),
     staticOutput: path.join(fixtures.root, 'build/static'),
     functionsOutput: path.join(fixtures.root, 'build/functions'),
-    functionsManifest: {},
+    manifest: { files: [] },
   }
 
   await onPostBuild(config, props)
@@ -221,7 +228,16 @@ test('onPostBuild - has functions, not configured', async () => {
     output: path.join(fixtures.root, 'build'),
     staticOutput: path.join(fixtures.root, 'build/static'),
     functionsOutput: path.join(fixtures.root, 'build/functions'),
-    functionsManifest: { '*': fixtures.files.lambda.path },
+    manifest: {
+      files: [
+        {
+          type: 'dynamic',
+          src: 'src',
+          dest: fixtures.files.lambda.path,
+          route: '*',
+        } as ManifestDynamicFile,
+      ],
+    },
   }
 
   let plan = 0
@@ -256,7 +272,16 @@ test(`onPostBuild - has functions, paths match`, async () => {
     output: path.join(fixtures.root, 'build'),
     staticOutput: path.join(fixtures.root, 'build/static'),
     functionsOutput: path.join(fixtures.root, 'build/functions'),
-    functionsManifest: { '*': fixtures.files.lambda.path },
+    manifest: {
+      files: [
+        {
+          type: 'dynamic',
+          src: 'src',
+          dest: fixtures.files.lambda.path,
+          route: '*',
+        } as ManifestDynamicFile,
+      ],
+    },
   }
 
   await onPostBuild(config, props)
@@ -289,7 +314,16 @@ test(`onPostBuild - has functions, paths don't match`, async () => {
     output: path.join(fixtures.root, 'build'),
     staticOutput: path.join(fixtures.root, 'build/static'),
     functionsOutput: path.join(fixtures.root, 'build/functions'),
-    functionsManifest: { '*': fixtures.files.lambda.path },
+    manifest: {
+      files: [
+        {
+          type: 'dynamic',
+          src: 'src',
+          dest: fixtures.files.lambda.path,
+          route: '*',
+        } as ManifestDynamicFile,
+      ],
+    },
   }
 
   await onPostBuild(config, props)

--- a/packages/adapter-node/lib/__tests__/adapter.ts
+++ b/packages/adapter-node/lib/__tests__/adapter.ts
@@ -50,8 +50,15 @@ test('adapter', async () => {
   adapter(
     {
       staticOutput: path.join(fixture.root, 'build/static'),
-      functionsManifest: {
-        [route]: fixture.files.fn.path,
+      manifest: {
+        files: [
+          {
+            type: 'dynamic',
+            src: 'src',
+            dest: fixture.files.fn.path,
+            route,
+          },
+        ],
       },
     },
     { port: 4000 }

--- a/packages/adapter-vercel/lib/adapter.ts
+++ b/packages/adapter-vercel/lib/adapter.ts
@@ -5,7 +5,7 @@
 import { parse as parseUrl } from 'url'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { Response } from 'lambda-types'
-import { Handler, Event, Context } from 'presta'
+import type { Handler, Event, Context } from 'presta'
 import { normalizeHeaders } from '@presta/utils/normalizeHeaders'
 import { parseQueryStringParameters } from '@presta/utils/parseQueryStringParameters'
 import { sendServerlessResponse } from '@presta/utils/sendServerlessResponse'

--- a/packages/presta/lib/__tests__/config.ts
+++ b/packages/presta/lib/__tests__/config.ts
@@ -104,7 +104,7 @@ test('create', async () => {
     plugins: [],
     staticOutputDir: path.join(output, 'static'),
     functionsOutputDir: path.join(output, 'functions'),
-    functionsManifest: path.join(output, 'routes.json'),
+    manifestFilepath: path.join(output, 'manifest.json'),
   }
 
   assert.equal(config, generated)

--- a/packages/presta/lib/__tests__/outputLambdas.ts
+++ b/packages/presta/lib/__tests__/outputLambdas.ts
@@ -33,16 +33,11 @@ test('outputLambdas', async () => {
     config
   )
 
-  assert.equal(slug[0], `/:slug`)
-  assert.ok(slug[1].includes(`slug.js`))
+  assert.equal(slug.route, `/:slug`)
+  assert.ok(slug.dest.includes(`slug.js`))
 
-  assert.equal(fallback[0], `/:slug?`)
-  assert.ok(fallback[1].includes(`fallback.js`))
-
-  const manifest = require(config.functionsManifest)
-
-  assert.equal(manifest[slug[0]], slug[1])
-  assert.equal(manifest[fallback[0]], fallback[1])
+  assert.equal(fallback.route, `/:slug?`)
+  assert.ok(fallback.dest.includes(`fallback.js`))
 })
 
 test('outputLambdas - hashed in prod', async () => {
@@ -62,9 +57,9 @@ test('outputLambdas - hashed in prod', async () => {
   const [slug] = outputLambdas([fixture.files.slug.path], config)
   const hash = hashContent(fixture.files.slug.content)
 
-  assert.equal(slug[0], `/:slug`)
-  assert.ok(slug[1].includes(`slug-${hash}.js`))
-  assert.ok(fs.existsSync(slug[1]))
+  assert.equal(slug.route, `/:slug`)
+  assert.ok(slug.dest.includes(`slug-${hash}.js`))
+  assert.ok(fs.existsSync(slug.dest))
 })
 
 test('slugify', async () => {

--- a/packages/presta/lib/config.ts
+++ b/packages/presta/lib/config.ts
@@ -18,7 +18,7 @@ export type Config = Options & {
   env: string
   staticOutputDir: string
   functionsOutputDir: string
-  functionsManifest: string
+  manifestFilepath: string
 }
 
 export const defaultConfigFilepath = 'presta.config.js'
@@ -87,6 +87,6 @@ export function create(
     ...config,
     staticOutputDir: path.join(config.output, 'static'),
     functionsOutputDir: path.join(config.output, 'functions'),
-    functionsManifest: path.join(config.output, 'routes.json'),
+    manifestFilepath: path.join(config.output, 'manifest.json'),
   }
 }

--- a/packages/presta/lib/createEmitter.ts
+++ b/packages/presta/lib/createEmitter.ts
@@ -1,3 +1,5 @@
+import { Manifest } from './manifest'
+
 export enum Events {
   PostBuild = 'post-build',
   BuildFile = 'build-file',
@@ -10,7 +12,7 @@ export type HookPostBuildPayload = {
   output: string
   staticOutput: string
   functionsOutput: string
-  functionsManifest: Record<string, string>
+  manifest: Manifest
 }
 
 export type HookBuildFilePayload = {

--- a/packages/presta/lib/index.ts
+++ b/packages/presta/lib/index.ts
@@ -10,3 +10,10 @@ export * from './lambda'
 export { Config, Options } from './config'
 export { HookPostBuildPayload, HookBuildFilePayload } from './createEmitter'
 export { createPlugin, PluginInit, Plugin, PluginInterface } from './plugins'
+export {
+  Manifest,
+  ManifestDynamicFile,
+  ManifestStaticFile,
+  getDynamicFilesFromManifest,
+  getStaticFilesFromManifest,
+} from './manifest'

--- a/packages/presta/lib/manifest.ts
+++ b/packages/presta/lib/manifest.ts
@@ -1,0 +1,47 @@
+import fs from 'fs-extra'
+
+import { Config } from './config'
+import { StaticFilesMap } from './buildStaticFiles'
+
+export type ManifestDynamicFile = {
+  type: 'dynamic'
+  src: string
+  dest: string
+  route: string
+}
+
+export type ManifestStaticFile = {
+  type: 'static'
+  src: string
+  dest: string
+}
+
+export type ManifestFile = ManifestDynamicFile | ManifestStaticFile
+
+export type Manifest = {
+  files: ManifestFile[]
+}
+
+export function staticFilesMapToManifestFiles(staticFilesMap: StaticFilesMap): ManifestStaticFile[] {
+  return Object.keys(staticFilesMap)
+    .map((src) => {
+      return staticFilesMap[src].map((dest) => ({
+        type: 'static',
+        src,
+        dest,
+      })) as ManifestStaticFile[]
+    })
+    .flat()
+}
+
+export function getDynamicFilesFromManifest(manifest: Manifest): ManifestDynamicFile[] {
+  return manifest.files.filter((file) => file.type === 'dynamic') as ManifestDynamicFile[]
+}
+
+export function getStaticFilesFromManifest(manifest: Manifest): ManifestStaticFile[] {
+  return manifest.files.filter((file) => file.type === 'static') as ManifestStaticFile[]
+}
+
+export function writeManifest(manifest: Manifest, config: Config): void {
+  fs.outputFileSync(config.manifestFilepath, JSON.stringify(manifest, null, '  '), 'utf8')
+}


### PR DESCRIPTION
Replaces `routes.json` functions manifest with a generic `manifest.json` that contains all generated static and dynamic files.

Fixes #198.